### PR TITLE
Raw docstrings when using math

### DIFF
--- a/src/dmf/dmf.py
+++ b/src/dmf/dmf.py
@@ -533,7 +533,7 @@ class VariationalPathOpt(ABC, cyipopt.Problem):
         return np.tensordot(P_temp[nu].T,self.coefs,1)
 
     def set_coefs_angs(self,coefs=None,angs=None):
-        """
+        r"""
         Update the B-spline coefficients and/or rotation angles.
 
         This method updates ``coefs`` and ``angs`` if the

--- a/src/dmf/torch/dmf.py
+++ b/src/dmf/torch/dmf.py
@@ -658,7 +658,7 @@ class VariationalPathOpt(ABC, cyipopt.Problem):
         return np.tensordot(P_temp[nu].T,self.coefs,1)
 
     def set_coefs_angs(self,coefs=None,angs=None):
-        """
+        r"""
         Update the B-spline coefficients and/or rotation angles.
 
         This method updates ``coefs`` and ``angs`` if the


### PR DESCRIPTION
This is part of the [JOSS review](https://github.com/openjournals/joss-reviews/issues/10379).

I noticed warnings about this when running tests.  The rendered docs look like this:

<img width="767" height="362" alt="Screenshot 2026-07-07 at 11 05 30 AM" src="https://github.com/user-attachments/assets/7417cff9-1e4b-469d-b912-58e33870caca" />
